### PR TITLE
fix variable overload

### DIFF
--- a/localbase/api/actions/delete.js
+++ b/localbase/api/actions/delete.js
@@ -59,7 +59,7 @@ export default function deleteIt() {
                 { collection: collectionToDelete }
               )
             )
-          }).catch(error => {
+          }).catch(err => {
             reject(
               error.call(
                 this,


### PR DESCRIPTION
Changed `error` catch parameter to `err`. This supports a consistent naming scheme with the rest of the repo, and does not overload the `error` function. The variable `error` in the catch block scope threw an Error because the argument passed to the catch block was not a function.